### PR TITLE
Udpates to the abstract and the introduction

### DIFF
--- a/draft-gerdes-ace-dtls-authorize.md
+++ b/draft-gerdes-ace-dtls-authorize.md
@@ -97,7 +97,7 @@ entity:
 --- abstract
 
 This specification defines a profile for delegating client
-authentication and authorization in a constrained environment for
+authentication and authorization in a constrained environment by
 establishing a Datagram Transport Layer Security (DTLS) channel between resource-constrained nodes.
 The protocol relies on DTLS for communication security
 between entities in a constrained network. A
@@ -118,10 +118,18 @@ access token, bound to a key (the proof-of-possession key) to authorize its
 access to the resource server.  DTLS provides communication security,
 proof of possession, and server authentication.  Optionally the client and the
 resource server may also use CoAP over DTLS to communicate with the
-authorization server.  The DTLS PSK handshake {{RFC4279}} provides the
-proof-of-possession for the key tied to the access token.  Furthermore
-the psk_identity parameter in the DTLS PSK handshake is used to transfer
-the access token from the client to the resource server.
+authorization server.  This specification supports the DTLS PSK handshake 
+{{RFC4279}} and the DTLS handshake with Raw Public Keys (RPK) {{RFC7250}}. 
+
+The DTLS PSK handshake {{RFC4279}} provides the proof-of-possession for the key
+tied to the access token.  Furthermore the psk_identity parameter in the DTLS 
+PSK handshake is used to transfer the access token from the client to the
+resource server.
+
+The DTLS RPK handshake {{RFC7250}} requires client authentication to provide
+proof-of-possession for the key tied to the access token.  Here the access token
+needs to be transferred to the resource server before the handshake is initiated,
+as described in section 8.1 of {{I-D.ietf-ace-oauth-authz}}.
 
 Note: While the scope of this draft is on client and resource server
 : communicating using CoAP over DTLS, it is expected that it applies


### PR DESCRIPTION
I made some updates to the introduction (it was solely referring to PSK, I added RPK). I also changed one word in the abstract for clarification, please double-check that one, since it might change the meaning in an unintended way.
